### PR TITLE
Android 4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# rhino-android
+
+
+Взяв за основу [rhino-android](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=2ahUKEwjgvITP7LXoAhUl86YKHf9YAk4QFjAAegQIBRAB&url=https%3A%2F%2Fgithub.com%2FF43nd1r%2Frhino-android&usg=AOvVaw0h2tnQYM-QlkJMBJ-EtD3H), добавил 
+1. ZipFileAndroidClassLoader, для поддержки 4х андроидов
+2. Запуск скрипта "1" + "1" в main activity для проверки
+3. Выложил на jitpack и втянул в автору
+
+Когда откажемся от 4х андроидов, вернемся на rhino-android
+
+Проблема была с представлением dex файлов, библиотека rhino в райнтайме генерит dex файлы: javaScriptCompile -> bytecode -> dex file -> dalvik/art classLoader
+Для 4х андроидов нужен особый формат classes.dex.zip
+Те нужно положить dex файлы в zip архив
+И потом считать классы с помощью DexClassLoader

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rhino-android
 
 
-Взяв за основу [rhino-android](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=2ahUKEwjgvITP7LXoAhUl86YKHf9YAk4QFjAAegQIBRAB&url=https%3A%2F%2Fgithub.com%2FF43nd1r%2Frhino-android&usg=AOvVaw0h2tnQYM-QlkJMBJ-EtD3H), добавил 
+Взяв за основу [rhino-android](https://github.com/F43nd1r/rhino-android), добавил
 1. ZipFileAndroidClassLoader, для поддержки 4х андроидов
 2. Запуск скрипта "1" + "1" в main activity для проверки
 3. Выложил на jitpack и втянул в автору

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,4 +38,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation project(path: ':rhino-android-library')
+    implementation 'io.reactivex:rxjava:1.2.9'
+    implementation 'io.reactivex:rxandroid:1.2.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
@@ -32,4 +37,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation project(path: ':rhino-android-library')
 }

--- a/app/src/main/java/com/danser/rhino_android/JsExecutor.kt
+++ b/app/src/main/java/com/danser/rhino_android/JsExecutor.kt
@@ -97,7 +97,7 @@ class JsExecutor(private val context: Context) : IJsExecutor {
         }
 
     private fun logError(th: Throwable) {
-        Log.e("JsEsecuter", th.message)
+        Log.e(JsExecutor::class.java.simpleName, th.message ?: "")
         Handler(Looper.getMainLooper()).post {
             Toast.makeText(context, th.message, Toast.LENGTH_LONG).show()
         }

--- a/app/src/main/java/com/danser/rhino_android/JsExecutor.kt
+++ b/app/src/main/java/com/danser/rhino_android/JsExecutor.kt
@@ -1,0 +1,110 @@
+package com.danser.rhino_android
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import com.danser.rhino_android_library.RhinoAndroidHelper
+import org.mozilla.javascript.ImporterTopLevel
+import org.mozilla.javascript.Script
+import org.mozilla.javascript.Scriptable
+import org.mozilla.javascript.ScriptableObject
+import rx.Completable
+import rx.Single
+import rx.schedulers.Schedulers
+import java.util.concurrent.ConcurrentHashMap
+
+
+interface IJsExecutor {
+    fun execute(code: JsCode): Single<String>
+    fun compileScriptAndCache(code: String): Completable
+}
+
+class JsExecutor(private val context: Context) : IJsExecutor {
+
+    private val scripts: MutableMap<Int, Script> = ConcurrentHashMap()
+    private val failedScripts: MutableMap<Int, String> = ConcurrentHashMap()
+
+    override fun execute(code: JsCode): Single<String> = Single.create<String> { subscriber ->
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            val rhinoContext = getRhinoContext()
+            val key = code.code.hashCode()
+            failedScripts[key]?.let { errorMessage ->
+                val error =
+                    IllegalArgumentException("Script already was tried to compile or execute with error: $errorMessage")
+                subscriber.onError(error)
+                return@create
+            }
+
+            //compile script or get precompiled script from cache
+            val script = compileScriptCached(rhinoContext, code.code)
+
+            //then execute it
+            val result: String = script.execute(rhinoContext, code.arguments)
+
+            subscriber.onSuccess(result)
+        } catch (th: Throwable) {
+            subscriber.onError(th)
+        } finally {
+            org.mozilla.javascript.Context.exit()
+        }
+    }
+        .subscribeOn(Schedulers.computation())
+        .doOnError { throwable ->
+            logError(throwable)
+            failedScripts[code.code.hashCode()] = throwable.message.orEmpty()
+        }
+
+    override fun compileScriptAndCache(code: String): Completable = Completable
+        .fromAction { compileScriptCached(getRhinoContext(), code) }
+        .subscribeOn(Schedulers.computation())
+        .doOnError { throwable ->
+            logError(throwable)
+            failedScripts[code.hashCode()] = throwable.message.orEmpty()
+        }
+
+    private fun compileScriptCached(context: org.mozilla.javascript.Context, code: String): Script =
+        scripts[code.hashCode()] ?: context.compileString(
+            code,
+            null,
+            1,
+            null
+        ).apply { scripts[code.hashCode()] = this }
+
+    private fun Script.execute(
+        context: org.mozilla.javascript.Context,
+        arguments: Map<String, Any>
+    ): String {
+        val scope = ImporterTopLevel(context)
+        putArguments(scope, arguments)
+        return this.exec(context, scope) as String
+    }
+
+    private fun putArguments(scope: Scriptable, arguments: Map<String, Any>) {
+        arguments.entries.forEach { (key, value) ->
+            val arg: Any = org.mozilla.javascript.Context.javaToJS(value, scope)
+            ScriptableObject.putProperty(scope, key, arg)
+        }
+    }
+
+    private fun getRhinoContext(): org.mozilla.javascript.Context = RhinoAndroidHelper(context)
+        .enterContext()
+        .apply {
+            optimizationLevel = 1
+
+        }
+
+    private fun logError(th: Throwable) {
+        Log.e("JsEsecuter", th.message)
+        Handler(Looper.getMainLooper()).post {
+            Toast.makeText(context, th.message, Toast.LENGTH_LONG).show()
+        }
+    }
+}
+
+data class JsCode(
+    val code: String,
+    val arguments: Map<String, Any>
+)

--- a/app/src/main/java/com/danser/rhino_android/MainActivity.kt
+++ b/app/src/main/java/com/danser/rhino_android/MainActivity.kt
@@ -2,11 +2,17 @@ package com.danser.rhino_android
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.widget.Toast
+import rx.android.schedulers.AndroidSchedulers
 
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        JsExecutor(this).execute(JsCode(""""1" + "1"""", emptyMap()))
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { Toast.makeText(this, it, Toast.LENGTH_SHORT).show() }
     }
 }

--- a/rhino-android-library/build.gradle
+++ b/rhino-android-library/build.gradle
@@ -28,8 +28,6 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.0.2'
 
     api 'org.mozilla:rhino:1.7.11'
     implementation 'androidx.annotation:annotation:1.1.0'

--- a/rhino-android-library/consumer-rules.pro
+++ b/rhino-android-library/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keepattributes Signature
+-dontwarn org.mozilla.javascript.**

--- a/rhino-android-library/proguard-rules.pro
+++ b/rhino-android-library/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keepattributes Signature
+-dontwarn org.mozilla.javascript.**

--- a/rhino-android-library/src/main/java/com/danser/rhino_android_library/AndroidContextFactory.java
+++ b/rhino-android-library/src/main/java/com/danser/rhino_android_library/AndroidContextFactory.java
@@ -55,8 +55,11 @@ public class AndroidContextFactory extends ContextFactory {
     public BaseAndroidClassLoader createClassLoader(ClassLoader parent) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             return new InMemoryAndroidClassLoader(parent);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            return new FileAndroidClassLoader(parent, cacheDirectory);
+        } else {
+            return new ZipFileAndroidClassLoader(parent, cacheDirectory);
         }
-        return new FileAndroidClassLoader(parent, cacheDirectory);
     }
 
     @Override

--- a/rhino-android-library/src/main/java/com/danser/rhino_android_library/FileAndroidClassLoader.java
+++ b/rhino-android-library/src/main/java/com/danser/rhino_android_library/FileAndroidClassLoader.java
@@ -16,8 +16,12 @@
 
 package com.danser.rhino_android_library;
 
+import android.os.Build;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
 import com.android.dex.Dex;
 import dalvik.system.PathClassLoader;
 
@@ -29,6 +33,7 @@ import java.io.IOException;
  * @since 24.10.2017
  */
 @SuppressWarnings("ResultOfMethodCallIgnored")
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 class FileAndroidClassLoader extends BaseAndroidClassLoader {
     private static int instanceCounter = 0;
     private final File dexFile;

--- a/rhino-android-library/src/main/java/com/danser/rhino_android_library/ZipFileAndroidClassLoader.kt
+++ b/rhino-android-library/src/main/java/com/danser/rhino_android_library/ZipFileAndroidClassLoader.kt
@@ -55,7 +55,7 @@ internal class ZipFileAndroidClassLoader(
         val zipPath = dexFile.path + ".zip"
         try {
             dex.writeTo(dexFile)
-            ZipArchiver.makeZipArchive(zipPath, mapOf(dexFile.path to "classes"))
+            ZipArchiver.makeZipArchive(zipPath, mapOf(dexFile.path to "classes.dex"))
         } catch (e: IOException) {
             e.printStackTrace()
         }

--- a/rhino-android-library/src/main/java/com/danser/rhino_android_library/ZipFileAndroidClassLoader.kt
+++ b/rhino-android-library/src/main/java/com/danser/rhino_android_library/ZipFileAndroidClassLoader.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017 Lukas Morawietz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.danser.rhino_android_library
+
+import com.android.dex.Dex
+import com.danser.rhino_android_library.utils.ZipArchiver
+import dalvik.system.DexClassLoader
+import dalvik.system.PathClassLoader
+import java.io.File
+import java.io.IOException
+
+/**
+ *  This class is for Android < 21 DexClassLoader support
+ *
+ *  Android >= 21 looks for some.dex
+ *  Android <  21 look for some.dex inside zip archive
+ *
+ *  So we need to write dex file and zip it before using DexClassLoader
+ *
+ */
+internal class ZipFileAndroidClassLoader(
+    parent: ClassLoader?,
+    cacheDir: File
+) : BaseAndroidClassLoader(parent) {
+
+    private val dexFile: File
+
+    /**
+     * Create a new instance with the given parent classloader
+     *
+     * @param parent the parent
+     */
+    init {
+        val id = instanceCounter++
+        dexFile = File(cacheDir, "$id.dex")
+        cacheDir.mkdirs()
+        reset()
+    }
+
+    @Throws(ClassNotFoundException::class)
+    override fun loadClass(dex: Dex, name: String): Class<*> {
+        val zipPath = dexFile.path + ".zip"
+        try {
+            dex.writeTo(dexFile)
+            ZipArchiver.makeZipArchive(zipPath, listOf(dexFile.path))
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+        val loader = DexClassLoader(zipPath, dexFile.parent, "", parent)
+        return loader.loadClass(name)
+    }
+
+    override fun getLastDex(): Dex? {
+        if (dexFile.exists()) {
+            try {
+                return Dex(dexFile)
+            } catch (e: IOException) {
+                e.printStackTrace()
+            }
+        }
+        return null
+    }
+
+    override fun reset() {
+        dexFile.delete()
+    }
+
+    companion object {
+        private var instanceCounter = 0
+    }
+}

--- a/rhino-android-library/src/main/java/com/danser/rhino_android_library/ZipFileAndroidClassLoader.kt
+++ b/rhino-android-library/src/main/java/com/danser/rhino_android_library/ZipFileAndroidClassLoader.kt
@@ -55,7 +55,7 @@ internal class ZipFileAndroidClassLoader(
         val zipPath = dexFile.path + ".zip"
         try {
             dex.writeTo(dexFile)
-            ZipArchiver.makeZipArchive(zipPath, listOf(dexFile.path))
+            ZipArchiver.makeZipArchive(zipPath, mapOf(dexFile.path to "classes"))
         } catch (e: IOException) {
             e.printStackTrace()
         }

--- a/rhino-android-library/src/main/java/com/danser/rhino_android_library/utils/ZipArchiver.kt
+++ b/rhino-android-library/src/main/java/com/danser/rhino_android_library/utils/ZipArchiver.kt
@@ -11,10 +11,11 @@ object ZipArchiver {
 
     fun makeZipArchive(outputPath: String, files: Map<String, String>) {
         try {
-            val outputFile = File(outputPath)
-            outputFile.mkdirs()
-            outputFile.delete()
-            outputFile.createNewFile()
+            File(outputPath).apply {
+                mkdirs()
+                delete()
+                createNewFile()
+            }
             val zipOutputStream =
                 ZipOutputStream(BufferedOutputStream(FileOutputStream(outputPath)))
             val data = ByteArray(BUFFER_SIZE)

--- a/rhino-android-library/src/main/java/com/danser/rhino_android_library/utils/ZipArchiver.kt
+++ b/rhino-android-library/src/main/java/com/danser/rhino_android_library/utils/ZipArchiver.kt
@@ -1,0 +1,36 @@
+package com.danser.rhino_android_library.utils
+
+import android.util.Log
+import java.io.*
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+object ZipArchiver {
+
+    private const val BUFFER_SIZE = 8192
+
+    fun makeZipArchive(outputPath: String, files: List<String>) {
+        try {
+            val outputFile = File(outputPath)
+            outputFile.mkdirs()
+            outputFile.delete()
+            val zipOutputStream =
+                ZipOutputStream(BufferedOutputStream(FileOutputStream(outputPath)))
+            val data = ByteArray(BUFFER_SIZE)
+            for (file in files) {
+                Log.v(ZipArchiver::class.java.simpleName, "Zipped: $file")
+                val fileInputStream = BufferedInputStream(FileInputStream(file), BUFFER_SIZE)
+                val entry = ZipEntry(file.substring(file.lastIndexOf("/") + 1))
+                zipOutputStream.putNextEntry(entry)
+                var count: Int
+                while (fileInputStream.read(data, 0, BUFFER_SIZE).also { count = it } != -1) {
+                    zipOutputStream.write(data, 0, count)
+                }
+                fileInputStream.close()
+            }
+            zipOutputStream.close()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/rhino-android-library/src/main/java/com/danser/rhino_android_library/utils/ZipArchiver.kt
+++ b/rhino-android-library/src/main/java/com/danser/rhino_android_library/utils/ZipArchiver.kt
@@ -15,7 +15,6 @@ object ZipArchiver {
             outputFile.mkdirs()
             outputFile.delete()
             outputFile.createNewFile()
-            outputFile.setReadable(true, false)
             val zipOutputStream =
                 ZipOutputStream(BufferedOutputStream(FileOutputStream(outputPath)))
             val data = ByteArray(BUFFER_SIZE)

--- a/rhino-android-library/src/main/java/com/danser/rhino_android_library/utils/ZipArchiver.kt
+++ b/rhino-android-library/src/main/java/com/danser/rhino_android_library/utils/ZipArchiver.kt
@@ -9,7 +9,7 @@ object ZipArchiver {
 
     private const val BUFFER_SIZE = 8192
 
-    fun makeZipArchive(outputPath: String, files: List<String>) {
+    fun makeZipArchive(outputPath: String, files: Map<String, String>) {
         try {
             val outputFile = File(outputPath)
             outputFile.mkdirs()
@@ -19,10 +19,10 @@ object ZipArchiver {
             val zipOutputStream =
                 ZipOutputStream(BufferedOutputStream(FileOutputStream(outputPath)))
             val data = ByteArray(BUFFER_SIZE)
-            for (file in files) {
-                Log.v(ZipArchiver::class.java.simpleName, "Zipped: $file")
+            for ((file, nameInZip) in files) {
+                Log.v(ZipArchiver::class.java.simpleName, "Zipped: $file as $nameInZip")
                 val fileInputStream = BufferedInputStream(FileInputStream(file), BUFFER_SIZE)
-                val entry = ZipEntry(file.substring(file.lastIndexOf("/") + 1))
+                val entry = ZipEntry(nameInZip)
                 zipOutputStream.putNextEntry(entry)
                 var count: Int
                 while (fileInputStream.read(data, 0, BUFFER_SIZE).also { count = it } != -1) {

--- a/rhino-android-library/src/main/java/com/danser/rhino_android_library/utils/ZipArchiver.kt
+++ b/rhino-android-library/src/main/java/com/danser/rhino_android_library/utils/ZipArchiver.kt
@@ -14,6 +14,8 @@ object ZipArchiver {
             val outputFile = File(outputPath)
             outputFile.mkdirs()
             outputFile.delete()
+            outputFile.createNewFile()
+            outputFile.setReadable(true, false)
             val zipOutputStream =
                 ZipOutputStream(BufferedOutputStream(FileOutputStream(outputPath)))
             val data = ByteArray(BUFFER_SIZE)


### PR DESCRIPTION
Взяв за основу [rhino-android](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=2ahUKEwjgvITP7LXoAhUl86YKHf9YAk4QFjAAegQIBRAB&url=https%3A%2F%2Fgithub.com%2FF43nd1r%2Frhino-android&usg=AOvVaw0h2tnQYM-QlkJMBJ-EtD3H), добавил 
1. ZipFileAndroidClassLoader, для поддержки 4х андроидов
2. Запуск скрипта "1" + "1" в main activity для проверки
3. Выложил на jitpack и втянул в автору

Когда откажемся от 4х андроидов, вернемся на rhino-android

Проблема была с представлением dex файлов, библиотека rhino в райнтайме генерит dex файлы: javaScriptCompile -> bytecode -> dex file -> dalvik/art classLoader
Для 4х андроидов нужен особый формат classes.dex.zip
Те нужно положить dex файлы в zip архив
И потом считать классы с помощью DexClassLoader
